### PR TITLE
run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-cp -r /home/idinium/autobot.tf/index.html /data/www/autobot.tf
+cp ./index.html /data/www/autobot.tf
 
 echo "Done copy!"


### PR DESCRIPTION
changed path in CP to relative,
removed `-r` as it was unnecessary, because you are copying just one file.
NOT TESTED